### PR TITLE
#[47933069] updating ruby sdk to use HTTPS

### DIFF
--- a/lib/newrelic_plugin/new_relic_connection.rb
+++ b/lib/newrelic_plugin/new_relic_connection.rb
@@ -33,9 +33,7 @@ module NewRelic
         end
       end
       def url
-        host = @config["host"]||"platform-api.newrelic.com"
-        port = @config["port"]||443
-        "https://#{host}:#{port}"
+        @config["endpoint"] || "https://platform-api.newrelic.com"
       end
       def uri
         @config["uri"] || "/platform/v1/metrics"


### PR DESCRIPTION
Sidekick: @nathanhumbert 
Review: @leeatchison 

Adding https to the ruby sdk. Tested this with the newrelic example plugin and monitoring HTTPS traffic with tcpflow tool.
