### PR TITLE
#[51915289] Removing confidential statemnet from README. Renamed file to...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # New Relic Platform Agent SDK
 
-*CONFIDENTIAL* - All contents of this repository are CONFIDENTIAL
-per the terms of agreement between your organization and New
-Relic. Additionally, the code you develop based on the contents of
-this repository is also confidential and should not be shared outside
-your firm.
-
 ## Requirements
 
 * Tested with Ruby 1.8.7 and 1.9.3
@@ -41,7 +35,7 @@ suggestions and discuss with staff and other users.
 Also available is community support on IRC: we generally use #newrelic
 on irc.freenode.net
 
-Find a bug?  E-mail support@newrelic.com, or post it to
+Find a bug?  E-mail support @ New Relic, or post it to
 
 [support.newrelic.com](http://support.newrelic.com/).
 


### PR DESCRIPTION
... markdown extension

Sidekick: @nathanhumbert 
Review: @leeatchison 

Removed confidential statement from Ruby SDK. Split support email from feedback from support team. Renamed the rdoc file to a markdown file.
