### PR TITLE
Adds support for Erb directives in newrelic_plugin.yml

### DIFF
--- a/lib/newrelic_plugin/config.rb
+++ b/lib/newrelic_plugin/config.rb
@@ -25,7 +25,7 @@ module NewRelic
       # directly, rather the global method +config+ should be referenced instead.
       def initialize
         @options = YAML::load(Config.config_yaml) if Config.config_yaml
-        @options = YAML.load_file(ERB.new(File.read(Config.config_file), 0, '<>').result) unless @options
+        @options = YAML::load(ERB.new(File.read(Config.config_file), 0, '<>').result) unless @options
       end
 
       #


### PR DESCRIPTION
This makes it possible to pull configuration settings in from the environment. For example, one could configure the plugin automatically in a Heroku app like this:

``` erb
<%
  require 'uri'
  uri = URI.parse(ENV['DATABASE_URL'])
%>

newrelic:
  license_key: <%= ENV['NEW_RELIC_LICENSE_KEY'] %>
  # verbose: 1

agents:
  postgres:
    host: <%= uri.host %>
    port: <%= uri.port %>
    user: <%= uri.user %>
    password: <%= uri.password %>
    dbname: <%= uri.path.split('/')[1] %>
    sslmode: 'require'
```
