### PR TITLE
Downgrading timecop dependency to work with 1.8.7

### DIFF
--- a/newrelic_plugin.gemspec
+++ b/newrelic_plugin.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", '>= 5.0.6'
   s.add_development_dependency 'fakeweb'
   s.add_development_dependency 'pry'
-  s.add_development_dependency 'timecop'
+  s.add_development_dependency 'timecop', '= 0.6.1'
 
   s.files         = `git ls-files`.split($\)
   s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
The latest timecop gem supports only ruby 1.9.2+, we were running 0.6.3 and 0.6.2 has apparently been pulled, so downgrading to this version.  I've ran the changes with our entire test suite on all supported environments without issues.

Sidekick: @nathanhumbert 
