### PR TITLE
Configure license_key via ENV

### DIFF
--- a/lib/newrelic_plugin/run.rb
+++ b/lib/newrelic_plugin/run.rb
@@ -18,7 +18,7 @@ module NewRelic
       def initialize
         @config = NewRelic::Plugin::Config.config
         @context = NewRelic::Binding::Context.new(
-          @config.newrelic['license_key']
+          @config.newrelic['license_key'] || ENV['NEWRELIC_LICENSE_KEY']
         )
         configuration_and_logging
       end


### PR DESCRIPTION
In keeping with the tenants of the [12factor app](http://12factor.net/config) we don't like to write out credentials in to config.

When using the `newrelic_aws_cloudwatch_plugin`
https://github.com/newrelic-platform/newrelic_aws_cloudwatch_plugin/pull/35 allows us to avoid this with our AWS credentials.

This PR's small change grabs `NewRelic::Plugin::Config.config.newrelic['license_key']` from the Environment Variable `NEWRELIC_LICENSE_KEY` if the `license_key` is not present in `config/newrelic_plugin.yml`.

It's completely backwards compatible and saves a bunch of work to programatically generate a `config/newrelic_plugin.yml` from ENV if it's not accepted.
